### PR TITLE
Added the possibility to pass the operator as a tuple with the value …

### DIFF
--- a/prometheus_http_client/prometheus/client.py
+++ b/prometheus_http_client/prometheus/client.py
@@ -109,10 +109,14 @@ def _build_params(dic):
     if not isinstance(dic, dict):
         raise AssertionError("params must be dict type.")
     for k, v in dic.items():
-        if s:
-            s += ', {}="{}"'.format(k, v)
+        #if the value is a tuple then the caller likes to give also the operator like !=, =~ and so on.
+        #else the caller just likes label equals value filter
+        if isinstance(v, tuple):
+            s += '{}{}"{}", '.format(k,v[0],v[1])
         else:
-            s = '{}="{}"'.format(k, v)
+            s += '{}="{}", '.format(k, v)
+    #remove last comma
+    s = str(s[:-2])
     return '{%s}' % s
 
 


### PR DESCRIPTION
…in the case of a filter expression. The tuple is optional. The default operator remains equals